### PR TITLE
create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Collapse unity generated file diffs automatically
+*.asset linguist-generated
+*.mat linguist-generated
+*.meta linguist-generated
+*.prefab linguist-generated
+*.unity linguist-generated


### PR DESCRIPTION
Create a .gitattributes file to prevent the Unity generated files from clogging up diffs. Just to make life a little better.